### PR TITLE
Fix staging base URL

### DIFF
--- a/_config.staging.yml
+++ b/_config.staging.yml
@@ -1,4 +1,4 @@
-url: http://open-docs-staging.mesosphere.com.s3-website-us-west-1.amazonaws.com
+url: http://open-staging.mesosphere.com.s3-website-us-east-1.amazonaws.com
 env: staging
 
 assets:


### PR DESCRIPTION
Update the staging base URL to the static website endpoint for the S3 bucket: open-staging.mesosphere.com
