### PR TITLE
Clarify/reorder instructions for Exercise 10

### DIFF
--- a/advanced-course/installing-mesos.md
+++ b/advanced-course/installing-mesos.md
@@ -33,52 +33,32 @@ $ vagrant up node2
 $ vagrant ssh node2
 ```
 
-Once ``node2`` starts Install Mesos by using:
+On ``node2``, install Mesos:
 
 ```
 $ sudo rpm -Uvh http://repos.mesosphere.com/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm
 $ sudo yum -y install mesos
 ```
 
-Add the following lines to the ``/etc/hosts`` files::
+Update ``node2``'s ``/etc/hosts`` file to include entries for both nodes, *and* remove the "node2" name from the ``127.0.0.1`` entry on the first line. The file should look like this:
 
+    127.0.0.1   localhost [.. other localhosts ..]
+    ::1         localhost [.. other localhosts ..]
     192.168.33.10 node1
     192.168.33.11 node2
 
-Make sure to remove the "node2" mentioned on the first line for the 127.0.0.1 address.  If you do a ``ping node2`` then you should see 192.168.33.11 like this:
+Now, if you do a ``ping node2`` then you should see 192.168.33.11 like this:
 
 ```
 $ ping node2
 PING node2 (192.168.33.11) 56(84) bytes of data.
 64 bytes from node2 (192.168.33.11): icmp_seq=1 ttl=64 time=0.043 ms
-64 bytes from node2 (192.168.33.11): icmp_seq=2 ttl=64 time=0.027 ms
-64 bytes from node2 (192.168.33.11): icmp_seq=3 ttl=64 time=0.026 ms
-^C
---- node2 ping statistics ---
-3 packets transmitted, 3 received, 0% packet loss, time 2001ms
-rtt min/avg/max/mdev = 0.026/0.032/0.043/0.007 ms
-$
+...
 ```
 
-If you see 127.0.0.1 then you have your first line wrong.  *Remove* node2 from the first line.
+If node2 resolves to 127.0.0.1 then your first line is wrong.  *Remove* "node2" from the first line.
 
-Also do this for ``node1``:
-
-```
-$ vagrant ssh node1
-$ sudo vi /etc/hosts
-$ ping node2
-PING node2 (192.168.33.11) 56(84) bytes of data.
-64 bytes from node2 (192.168.33.11): icmp_seq=1 ttl=64 time=1.44 ms
-64 bytes from node2 (192.168.33.11): icmp_seq=2 ttl=64 time=0.341 ms
-^C
---- node2 ping statistics ---
-2 packets transmitted, 2 received, 0% packet loss, time 1001ms
-rtt min/avg/max/mdev = 0.341/0.892/1.443/0.551 ms
-$
-```
-
-Edit the ``/etc/mesos/zk`` file to point to the master node::
+Edit the ``/etc/mesos/zk`` file on ``node2`` to point to the master node:
 
     zk://192.168.33.10:2181/mesos
 
@@ -88,15 +68,31 @@ Start up Mesos as a slave with:
 $ sudo service mesos-slave start
 ```
 
-Validate that it restarts:
+Ensure that ``mesos-slave`` will be kept running across reboots/failures:
 
 ```
 $ sudo chkconfig mesos-slave on
 $ sudo chkconfig mesos-master off
+$ systemctl list-unit-files | grep mesos
+mesos-master.service                        disabled
+mesos-slave.service                         enabled
+```
+
+``node2`` is now configured. 
+
+Finally, switch over to ``node1`` and add an entry so that it can reach ``node2``. You don't need to remove the "node1" name from the first line this time:
+
+```
+$ vagrant ssh node1
+$ sudo vi /etc/hosts
+$ ping node2
+PING node2 (192.168.33.11) 56(84) bytes of data.
+64 bytes from node2 (192.168.33.11): icmp_seq=1 ttl=64 time=1.44 ms
+...
 ```
 
 Further Study
 -------------
 
-* Validate that the ``/etc/hosts`` file is updated with all of the IP addresses.
+* Validate that the ``/etc/hosts`` files across both nodes have been updated with all IP addresses.
 * Add these IP addresses and node names to your *local* ``/etc/hosts`` file.

--- a/advanced-course/installing-mesos.md
+++ b/advanced-course/installing-mesos.md
@@ -47,7 +47,7 @@ Update ``node2``'s ``/etc/hosts`` file to include entries for both nodes, *and* 
     192.168.33.10 node1
     192.168.33.11 node2
 
-Now, if you do a ``ping node2`` then you should see 192.168.33.11 like this:
+Now, if you do a ``ping node2`` then you should see ``192.168.33.11``:
 
 ```
 $ ping node2
@@ -80,7 +80,7 @@ mesos-slave.service                         enabled
 
 ``node2`` is now configured. 
 
-Finally, switch over to ``node1`` and add an entry so that it can reach ``node2``. You don't need to remove the "node1" name from the first line this time:
+Finally, switch over to ``node1`` and add an entry to ``/etc/hosts`` so that it can reach ``node2``. You don't need to remove the "node1" name from the first line this time:
 
 ```
 $ vagrant ssh node1


### PR DESCRIPTION
- Combine the edits to node1's /etc/hosts into a single step
- Perform all of node1's steps before switching to node2 to reduce confusion
- Rephrase some steps, and periodically specify the node that we're modifying
- Clarify that node1's 127.0.0.1 entry doesn't need to be updated