### PR TITLE
Remove -c flag when syncing from local

### DIFF
--- a/advanced-course/advanced-usage-of-chronos.md
+++ b/advanced-course/advanced-usage-of-chronos.md
@@ -114,7 +114,7 @@ This will run the ``date`` command every 5 minutes starting now.
 This will run the ``date`` command every 5 minutes starting now.  Save that file and  run this regular variant of the sync command:
 
 ```
-$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD -c
+$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD
 ```
 
 View the available jobs:


### PR DESCRIPTION
When the -c flag is present, chronos-sync.rb doesn't update Chronos from the local YAML file.

```
$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD -c
# nothing happened
$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD
These jobs will be updated:
About to update test

Old job:
---
...

New job:
---
name: test
command: date >> /tmp/job.log
shell: true
epsilon: PT30M
executor: ''
executorFlags: ''
retries: 2
owner: zed@mesosphere.io
async: false
cpus: 0.1
disk: 256.0
mem: 128.0
softError: false
uris: []
environmentVariables: []
arguments: []
highPriority: false
runAsUser: root
schedule: R//PT5M
scheduleTimeZone: ''

Sending PUT for `test` to /scheduler/iso8601
Finished checking/updating jobs
```