### PR TITLE
Update support and feedback documentation. Fixes #156

### DIFF
--- a/_data/docs_sidebar.yml
+++ b/_data/docs_sidebar.yml
@@ -116,6 +116,3 @@
 
 - title: "Downloads"
   href: "/downloads/mesos/"
-
-- title: "Support and Feedback"
-  external: "https://docs.mesosphere.com/support/"

--- a/index.md
+++ b/index.md
@@ -12,11 +12,9 @@ This site also contains [a listing of Apache Mesos packages by version](/downloa
 
 For product documentation related to [Mesosphere's DCOS](https://mesosphere.com/learn/), please see the [Mesosphere documentation](http://docs.mesosphere.com).
 
-
 ## Getting Started
 
 The best way to start learning about Mesos and the other open source components that make up the Mesosphere DCOS is to take our extensive [Advanced Mesos Course](/advanced-course/) course which teaches you everything you need to run Mesosphere's software.  This course consists of 20 exercises with video, quick reference commands, further study, and online live help comments.  The course takes you from nothing to running a four node cluster running Mesos, Marathon, Chronos, all built automatically with Ansible.  Take it at your own pace, and if you have any questions simply ask in the comments and we'll help you.
-
 
 ## Contributing
 
@@ -24,4 +22,6 @@ This documentation is open source. Community contributions to the open docs are 
 
 ## Support and Feedback
 
-Please see the [Support and Feedback](https://docs.mesosphere.com/support/) page on the Mesosphere documentation site for information on how to get in touch.
+Problems or questions related to this documentation should be [created as a new GitHub issue](https://github.com/mesosphere/open-docs/issues/new) or [asked on StackOverflow](http://ask.mesosphere.com). If you are able to fix the issue yourself, please consider [submitting a pull request](https://github.com/mesosphere/open-docs#2-submit-a-pull-request).
+
+Support information specific to the Mesosphere DCOS can be found at the [Support and Feedback page](https://docs.mesosphere.com/support/).


### PR DESCRIPTION
Add specific information on how to ask questions / raise issues with this documentation. Remove link to the Mesosphere DCOS documentation to avoid confusion and clarified this on the getting started page.