### PR TITLE
Remove [node1] from the Marathon cmd line for MesosDNS

### DIFF
--- a/advanced-course/building-and-running-mesos-dns.md
+++ b/advanced-course/building-and-running-mesos-dns.md
@@ -98,7 +98,7 @@ Test that mesos-dns runs locally first:
 In the Marathon GUI, create a new launcher named ``dns`` which uses the command we just tested:
 
 ```
-[node1]sudo /home/vagrant/go/src/github.com/mesosphere/mesos-dns/mesos-dns -v=1 -config=/home/vagrant/go/src/github.com/mesosphere/mesos-dns/config.json
+sudo /home/vagrant/go/src/github.com/mesosphere/mesos-dns/mesos-dns -v=1 -config=/home/vagrant/go/src/github.com/mesosphere/mesos-dns/config.json
 ```
 
 Add this in the ``Constraints`` field::


### PR DESCRIPTION
If I understand correctly [node1] was added to all the commands to make is clear to the users that these  are commands to be run on certain nodes.  Since the command line for MesosDNS is supposed to be put in Marathon UI it does not fit the scheme, also it may confuse a user who may copy the whole string including "[node1]"