### PR TITLE
Clarification about changing CPU and RAM values

### DIFF
--- a/advanced-course/using-the-marathon-gui.md
+++ b/advanced-course/using-the-marathon-gui.md
@@ -33,7 +33,7 @@ This exercise is entirely video based, and in the video we:
 2. Watch the Python process recover.
 3. Suspend the Python process which brings it to 0.
 4. Bring the process back up by going from 0 to 1 nodes.
-5. Make a new Python process with more CPU and RAM.
+5. Make a new Python process with different values for CPU and RAM. Make sure you can fit more than one process in the cluster according to the values you choose for CPU and RAM (recommended defaults: 0.1 CPU and 32MB RAM)
 6. Scale the Python process back up by using the ``$PORT`` variable and then add more nodes.
 7. Add 2 more nodes then show the ports working dynamically.
 


### PR DESCRIPTION
Current marathon default for new processes is 1 CPU, which makes it impossible to scale to more than 1 process on a default vagrant setup (1 CPU).