### PR TITLE
Added download page for Mesos RC packages.

### DIFF
--- a/_data/download_rc_versions.yml
+++ b/_data/download_rc_versions.yml
@@ -1,0 +1,25 @@
+- name: mesos
+  releases:
+
+    - name: 0.28.0-rc1
+      announcement: https://github.com/apache/mesos/blob/0.28.0-rc1/CHANGELOG
+      timestamp: 2016-03-02 00:00:00 +0000
+      packages:
+      - name: Ubuntu 15.04 (AMD 64)
+        path: ubuntu/pool/main/m/mesos/mesos_0.28.0-1.0.19.rc1.ubuntu1504_amd64.deb
+        sha256: c8e9f64de54ccf3855aefd412863409973028a34abcde19cf497deac47c583a8
+      - name: Ubuntu 14.04 (AMD 64)
+        path: ubuntu/pool/main/m/mesos/mesos_0.28.0-1.0.19.rc1.ubuntu1404_amd64.deb
+        sha256: e267345483752f65146b0e8bd760e0f251fcc38d7b3f256dd41f93274d648d3e
+      - name: Ubuntu 12.04 (AMD 64)
+        path: ubuntu/pool/main/m/mesos/mesos_0.28.0-1.0.19.rc1.ubuntu1204_amd64.deb
+        sha256: 8a7ffac40d763202e6135e3c9a4cbb9c076a4f63584bc94a9a0f55f972489199
+      - name: Debian 8 (AMD 64)
+        path: debian/pool/main/m/mesos/mesos_0.28.0-1.0.19.rc1.debian81_amd64.deb
+        sha256: 75594c948a7abc8ffd56ab8f6735f8941488d647335eea2dba98b894790292c8
+      - name: CentOS 7 (x86_64)
+        path: el-testing/7/x86_64/RPMS/mesos-0.28.0-1.0.19.rc1.centos701406.x86_64.rpm
+        sha256: fb861903a12b1ea497f0591fb2547cb128b0a75140656e87e38d1cc19cee113f
+      - name: CentOS 6 (x86_64)
+        path: el-testing/6/x86_64/RPMS/mesos-0.28.0-1.0.19.rc1.centos65.x86_64.rpm
+        sha256: ad2136b71d04b9bd1f0d0937f91e3492e42aa7efc6e2a92637c0e69305de4018

--- a/downloads/mesos-rc.md
+++ b/downloads/mesos-rc.md
@@ -1,20 +1,20 @@
 ---
 layout: default
-title: Download Apache Mesos Packages
+title: Download Apache Mesos RC Packages
 base: //downloads.mesosphere.io/master
 ---
 
 <div class="page-header">
-  <h1>Download Apache Mesos Packages</h1>
+  <h1>Download Apache Mesos RC Packages</h1>
 </div>
 
 <em>
-This page contains information about Apache Mesos release builds. For release candidate builds, see the [release-candidates](/downloads/mesos-rc/) page.
+This page contains information about Apache Mesos release candidate (RC) builds. For official releases, see the [releases](/downloads/mesos/) page.
 </em>
 
-### All releases
+### All Release Candidates
 
-{% for package in site.data.download_versions %}
+{% for package in site.data.download_rc_versions %}
 {% if package.name == "mesos" %}
 {% for rel in package.releases %}
 <h4>
@@ -27,7 +27,7 @@ This page contains information about Apache Mesos release builds. For release ca
 {% endif %}
 {% endfor %}
 
-{% for package in site.data.download_versions %}
+{% for package in site.data.download_rc_versions %}
 {% if package.name == "mesos" %}
 {% for rel in package.releases %}
 <div id="apache-mesos-{{ rel.release_group }}"></div>


### PR DESCRIPTION
Right now it doesn't contain links to python egg and SHA256 files. Will add them in future once we figure out the optimal strategy.