### PR TITLE
Fixed link to dcos.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Build is here: https://jenkins.mesosphere.com/service/jenkins/job/open-docs/
 
-**THIS CONTENT IS DEPRECATED. FOR THE LATEST INFORMATION, SEE <a href="dcos.io">dcos.io</a>.**
+**THIS CONTENT IS DEPRECATED. FOR THE LATEST INFORMATION, SEE <a href="dcos.io">https://github.com/mesosphere/dcos</a>.**
 
 This repository contains the Markdown files that comprise the [Mesosphere open documentation site](http://open.mesosphere.com).
 


### PR DESCRIPTION
I know that this repository is deprecated, but at least the link to the successor repository should work fine. However, I have found, that the current link "dcos.io" link leads to "https://github.com/mesosphere/open-docs/blob/master/dcos.io" returning a "404 Not found" message.

Did you mean to point to "https://github.com/mesosphere/dcos" instead? If, so, I propose to change the link accordingly.